### PR TITLE
add detectontology, readme, large OWL default

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,6 +49,21 @@ base_model = OWLViT(
 base_model.label("./context_images", extension=".jpg")
 ```
 
+To use a query images instead of query text, use a DetectionOntology instead of a CaptionOntology:
+
+```python
+from autodistill.detection import DetectionOntology
+
+from autodistill_owl_vit import OWLViT
+
+example_cat = PIL.Image.open("cat.jpg")
+
+base_model = OWLViT(ontology=DetectionOntology([(example_cat, "cat")]))
+
+# label all images in a folder called `context_images`
+base_model.label("./context_images", extension=".jpg")
+```
+
 ## License
 
 The code in this repository is licensed under an [Apache 2.0 license](LICENSE).

--- a/autodistill_owl_vit/__init__.py
+++ b/autodistill_owl_vit/__init__.py
@@ -1,3 +1,3 @@
-from autodistill_owl_vit.owlvit import OWLViT
+# from autodistill_owl_vit.owlvit import OWLViT
 
-__version__ = "0.1.0"
+# __version__ = "0.1.0"

--- a/autodistill_owl_vit/models.py
+++ b/autodistill_owl_vit/models.py
@@ -1,0 +1,191 @@
+import os
+
+import numpy as np
+import torch
+import torch.nn as nn
+from PIL import Image
+from torch.nn.functional import softmax
+from torchvision.ops import nms, batched_nms
+from transformers import AutoProcessor, OwlViTForObjectDetection
+from transformers.image_transforms import center_to_corners_format
+import random
+
+
+# Monkey patched for no in-place ops
+class PatchedOwlViTClassPredictionHead(nn.Module):
+    def __init__(self, original_cls_head):
+        super().__init__()
+
+        self.query_dim = original_cls_head.query_dim
+
+        self.dense0 = original_cls_head.dense0
+        self.pool = torch.nn.MaxPool1d(kernel_size=3, stride=3)
+
+    def forward(self, image_embeds, query_embeds):
+        image_class_embeds = self.dense0(image_embeds)
+
+        # Normalize image and text features
+        image_class_embeds = image_class_embeds / (
+            torch.linalg.norm(image_class_embeds, dim=-1, keepdim=True) + 1e-6
+        )
+        query_embeds = (
+            query_embeds / torch.linalg.norm(query_embeds, dim=-1, keepdim=True) + 1e-6
+        )
+
+        pred_sims = image_class_embeds @ query_embeds.transpose(1, 2)
+        pred_sims = self.pool(pred_sims)
+
+        return None, pred_sims
+
+
+class OwlViT(torch.nn.Module):
+    """
+    We don't train this that's why it's not an nn.Module subclass.
+    We just use this to get to the point where we can use the
+    classifier to filter noise.
+    """
+
+    def __init__(self, pretrained_model, query_bank):
+        super().__init__()
+
+        # Take the pretrained components that are useful to us
+        self.backbone = pretrained_model.owlvit.vision_model
+        self.post_post_layernorm = pretrained_model.layer_norm
+        self.class_predictor = PatchedOwlViTClassPredictionHead(
+            pretrained_model.class_head
+        )
+        self.box_head = pretrained_model.box_head
+        self.compute_box_bias = pretrained_model.compute_box_bias
+        self.sigmoid = pretrained_model.sigmoid
+
+        self.queries = torch.nn.Parameter(query_bank)
+
+    # Copied from transformers.models.clip.modeling_owlvit.OwlViTForObjectDetection.box_predictor
+    # Removed some comments and docstring to clear up clutter for now
+    def box_predictor(
+        self,
+        image_feats: torch.FloatTensor,
+        feature_map: torch.FloatTensor,
+    ) -> torch.FloatTensor:
+        pred_boxes = self.box_head(image_feats)
+        pred_boxes += self.compute_box_bias(feature_map)
+        pred_boxes = self.sigmoid(pred_boxes)
+        return center_to_corners_format(pred_boxes)
+
+    # Copied from transformers.models.clip.modeling_owlvit.OwlViTForObjectDetection.image_embedder
+    # Removed some comments and docstring to clear up clutter for now
+    def image_embedder(self, pixel_values):
+        vision_outputs = self.backbone(pixel_values=pixel_values)
+        last_hidden_state = vision_outputs.last_hidden_state
+        image_embeds = self.backbone.post_layernorm(last_hidden_state)
+
+        new_size = tuple(np.array(image_embeds.shape) - np.array((0, 1, 0)))
+        class_token_out = torch.broadcast_to(image_embeds[:, :1, :], new_size)
+
+        image_embeds = image_embeds[:, 1:, :] * class_token_out
+        image_embeds = self.post_post_layernorm(image_embeds)
+
+        new_size = (
+            image_embeds.shape[0],
+            int(np.sqrt(image_embeds.shape[1])),
+            int(np.sqrt(image_embeds.shape[1])),
+            image_embeds.shape[-1],
+        )
+        image_embeds = image_embeds.reshape(new_size)
+
+        return image_embeds
+
+    def forward(
+        self,
+        image: torch.Tensor,
+    ):
+        # Same naming convention as image_guided_detection
+        feature_map = self.image_embedder(image)
+        new_size = (
+            feature_map.shape[0],
+            feature_map.shape[1] * feature_map.shape[2],
+            feature_map.shape[3],
+        )
+
+        image_feats = torch.reshape(feature_map, new_size)
+
+        # Box predictions
+        pred_boxes = self.box_predictor(image_feats, feature_map)
+
+        pred_class_logits, pred_class_sims = self.class_predictor(
+            image_feats, self.queries
+        )
+
+        return (pred_boxes, pred_class_logits, pred_class_sims, None)
+
+
+class PostProcess:
+    def __init__(self, confidence_threshold=0.75, iou_threshold=0.3):
+        self.confidence_threshold = confidence_threshold
+        self.iou_threshold = iou_threshold
+
+    def __call__(self, all_pred_boxes, pred_classes):
+        # Just support batch size of one for now
+        pred_boxes = all_pred_boxes.squeeze(0)
+        pred_classes = pred_classes.squeeze(0)
+
+        top = torch.max(pred_classes, dim=1)
+        scores = top.values
+        classes = top.indices
+
+        idx = scores > self.confidence_threshold
+        scores = scores[idx]
+        classes = classes[idx]
+        pred_boxes = pred_boxes[idx]
+
+        idx = batched_nms(pred_boxes, scores, classes, iou_threshold=self.iou_threshold)
+        classes = classes[idx]
+        pred_boxes = pred_boxes[idx]
+        scores = scores[idx]
+
+        return pred_boxes.unsqueeze_(0), classes.unsqueeze_(0), scores.unsqueeze_(0)
+
+
+def load_model(labelmap, device):
+    os.environ["TOKENIZERS_PARALLELISM"] = "false"
+
+    _model = OwlViTForObjectDetection.from_pretrained("google/owlvit-base-patch32")
+    _processor = AutoProcessor.from_pretrained("google/owlvit-base-patch32")
+
+    to_encode = []
+    for label in labelmap.values():
+        to_encode.append(label)
+        to_encode.append("a photo of " + label)
+        to_encode.append("a " + label + " in an environment")
+
+    print("Initializing priors from labels...")
+    inputs = _processor(
+        text=[to_encode],
+        images=Image.new("RGB", (224, 224)),
+        return_tensors="pt",
+    )
+
+    with torch.no_grad():
+        queries = _model(**inputs).text_embeds
+
+    patched_model = OwlViT(pretrained_model=_model, query_bank=queries)
+
+    for name, parameter in patched_model.named_parameters():
+        conditions = [
+            "layers.11" in name,
+            "box" in name,
+            "post_layernorm" in name,
+            "class_predictor" in name,
+            "queries" in name,
+        ]
+        if any(conditions):
+            continue
+
+        parameter.requires_grad = False
+
+    print("Trainable parameters:")
+    for name, parameter in patched_model.named_parameters():
+        if parameter.requires_grad:
+            print(f"  {name}")
+    print()
+    return patched_model.to(device)

--- a/autodistill_owl_vit/models.py
+++ b/autodistill_owl_vit/models.py
@@ -10,7 +10,6 @@ from transformers import AutoProcessor, OwlViTForObjectDetection
 from transformers.image_transforms import center_to_corners_format
 import random
 
-
 # Monkey patched for no in-place ops
 class PatchedOwlViTClassPredictionHead(nn.Module):
     def __init__(self, original_cls_head):

--- a/autodistill_owl_vit/owl_finetuned.py
+++ b/autodistill_owl_vit/owl_finetuned.py
@@ -1,0 +1,76 @@
+import os
+from dataclasses import dataclass
+
+import numpy as np
+import supervision as sv
+import torch
+from autodistill.detection import CaptionOntology, DetectionBaseModel, DetectionOntology
+from PIL import Image
+from transformers import OwlViTForObjectDetection, OwlViTProcessor
+
+from owl_vit_object_detection.src.models import OwlViT
+
+HOME = os.path.expanduser("~")
+DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
+
+# model = OwlViTForObjectDetection.from_pretrained("google/owlvit-large-patch14").to(
+#     DEVICE
+# )
+model = OwlViT.load_state_dict(
+    "/home/jovyan/speir-datavol-115/models/owl_models/test.pt"
+).to(DEVICE)
+processor = OwlViTProcessor.from_pretrained("google/owlvit-large-patch14")
+
+
+@dataclass
+class OWLViT_finetuned(DetectionBaseModel):
+    ontology: CaptionOntology
+    owlvit_model: model
+
+    def __init__(self, ontology: CaptionOntology):
+        self.ontology = ontology
+        self.owlvit_model = model
+
+    def predict(self, input: str) -> sv.Detections:
+        labels = self.ontology.prompts()
+
+        image = Image.open(input).convert("RGB")
+
+        with torch.no_grad():
+            if isinstance(self.ontology, CaptionOntology):
+                # inputs = processor(text=labels, images=image, return_tensors="pt").to(
+                #     DEVICE
+                # )
+                image = processor(images=image, return_tensors="pt")[
+                    "pixel_values"
+                ].squeeze(0)
+                # pred_boxes in 'corners' format ?
+                pred_boxes, pred_class_logits, pred_class_sims, _ = model(image)
+            else:
+                print("Not implemented")
+                exit()
+
+            # target_sizes = torch.Tensor([image.size[::-1]]).to(DEVICE)
+
+            # results = processor.post_process(outputs=outputs, target_sizes=target_sizes)
+
+            # results = [
+            #     {k: v.to(torch.device("cpu")) for k, v in t.items()} for t in results
+            # ]
+
+            # i = 0
+
+            confidences = softmax(pred_class_logits)
+
+            detections = sv.Detections(
+                xyxy=np.array(pred_boxes),
+                class_id=np.array(pred_class_sims),
+                confidence=np.array(confidences),
+            )
+
+            return detections
+
+
+def softmax(logits):
+    e = np.exp(logits - np.max(logits))  # to prevent overflow
+    return e / e.sum(axis=-1, keepdims=True)

--- a/autodistill_owl_vit/owl_finetuned.py
+++ b/autodistill_owl_vit/owl_finetuned.py
@@ -1,14 +1,15 @@
 import os
-from dataclasses import dataclass
 
+# from dataclasses import dataclass
 import numpy as np
 import supervision as sv
 import torch
-from autodistill.detection import CaptionOntology, DetectionBaseModel, DetectionOntology
+from autodistill.detection import DetectionBaseModel
 from PIL import Image
 from transformers import OwlViTForObjectDetection, OwlViTProcessor
 
-from owl_vit_object_detection.src.models import OwlViT
+# from autodistill_owl_vit.owl_vit_object_detection.src.models import OwlViT
+from .models import OwlViT
 
 HOME = os.path.expanduser("~")
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
@@ -16,39 +17,62 @@ DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 # model = OwlViTForObjectDetection.from_pretrained("google/owlvit-large-patch14").to(
 #     DEVICE
 # )
-model = OwlViT.load_state_dict(
-    "/home/jovyan/speir-datavol-115/models/owl_models/test.pt"
-).to(DEVICE)
-processor = OwlViTProcessor.from_pretrained("google/owlvit-large-patch14")
+# checkpoint = torch.load("/home/jovyan/speir-datavol-115/models/owl_models/test.pt")
+# model = OwlViT().load_state_dict(checkpoint["model"]).to(DEVICE)
+# model = OwlViT().load_state_dict(torch.load('state_dict_path')).to(DEVICE)
+#     torch.load("/home/jovyan/speir-datavol-115/models/owl_models/test.pt")
+# ).to(DEVICE)
 
 
-@dataclass
-class OWLViT_finetuned(DetectionBaseModel):
-    ontology: CaptionOntology
-    owlvit_model: model
+# @dataclass
+class OWLViT_Finetuned(DetectionBaseModel):
+    # ontology: CaptionOntology
+    # owlvit_model: model
 
-    def __init__(self, ontology: CaptionOntology):
-        self.ontology = ontology
-        self.owlvit_model = model
+    def __init__(self, model_path, labelmap):
+        self.processor = OwlViTProcessor.from_pretrained("google/owlvit-large-patch14")
+        pretrained_model = OwlViTForObjectDetection.from_pretrained(
+            "google/owlvit-large-patch14"
+        )
+
+        to_encode = []
+        for label in labelmap.values():
+            to_encode.append(label)
+            to_encode.append("a photo of " + label)
+            to_encode.append("a " + label + " in an environment")
+
+        inputs = self.processor(
+            text=[to_encode],
+            images=Image.new("RGB", (224, 224)),
+            return_tensors="pt",
+        )
+        with torch.no_grad():
+            queries = pretrained_model(**inputs).text_embeds
+
+        self.ft_model = (
+            OwlViT(pretrained_model=pretrained_model, query_bank=queries)
+            .load_state_dict(torch.load(model_path))
+            .to(DEVICE)
+        )
 
     def predict(self, input: str) -> sv.Detections:
-        labels = self.ontology.prompts()
+        # labels = self.ontology.prompts()
 
         image = Image.open(input).convert("RGB")
 
         with torch.no_grad():
-            if isinstance(self.ontology, CaptionOntology):
-                # inputs = processor(text=labels, images=image, return_tensors="pt").to(
-                #     DEVICE
-                # )
-                image = processor(images=image, return_tensors="pt")[
-                    "pixel_values"
-                ].squeeze(0)
-                # pred_boxes in 'corners' format ?
-                pred_boxes, pred_class_logits, pred_class_sims, _ = model(image)
-            else:
-                print("Not implemented")
-                exit()
+            # if isinstance(self.ontology, CaptionOntology):
+            # inputs = processor(text=labels, images=image, return_tensors="pt").to(
+            #     DEVICE
+            # )
+            image = self.processor(images=image, return_tensors="pt")[
+                "pixel_values"
+            ].squeeze(0)
+            # pred_boxes in 'corners' format ?
+            pred_boxes, pred_class_logits, pred_class_sims, _ = self.ft_model(image)
+            # # else:
+            #     print("Not implemented")
+            #     exit()
 
             # target_sizes = torch.Tensor([image.size[::-1]]).to(DEVICE)
 

--- a/autodistill_owl_vit/owl_finetuned.py
+++ b/autodistill_owl_vit/owl_finetuned.py
@@ -4,7 +4,7 @@ import os
 import numpy as np
 import supervision as sv
 import torch
-from autodistill.detection import DetectionBaseModel
+from autodistill.detection.detection_base_model import DetectionBaseModel
 from PIL import Image
 from transformers import OwlViTForObjectDetection, OwlViTProcessor
 
@@ -74,9 +74,9 @@ class OWLViT_Finetuned(DetectionBaseModel):
             #     print("Not implemented")
             #     exit()
 
-            # target_sizes = torch.Tensor([image.size[::-1]]).to(DEVICE)
+            target_sizes = torch.Tensor([image.size[::-1]]).to(DEVICE)
 
-            # results = processor.post_process(outputs=outputs, target_sizes=target_sizes)
+            results = self.processor.post_process(outputs=outputs, target_sizes=target_sizes)
 
             # results = [
             #     {k: v.to(torch.device("cpu")) for k, v in t.items()} for t in results

--- a/autodistill_owl_vit/owlvit.py
+++ b/autodistill_owl_vit/owlvit.py
@@ -4,7 +4,10 @@ from dataclasses import dataclass
 import numpy as np
 import supervision as sv
 import torch
-from autodistill.detection import CaptionOntology, DetectionBaseModel, DetectionOntology
+from autodistill.detection.caption_ontology import CaptionOntology
+from autodistill.detection.detection_base_model import DetectionBaseModel
+
+# , DetectionBaseModel, DetectionOntology
 from PIL import Image
 from transformers import OwlViTForObjectDetection, OwlViTProcessor
 

--- a/autodistill_owl_vit/owlvit.py
+++ b/autodistill_owl_vit/owlvit.py
@@ -4,15 +4,18 @@ from dataclasses import dataclass
 import numpy as np
 import supervision as sv
 import torch
+from autodistill.detection import CaptionOntology, DetectionBaseModel, DetectionOntology
 from PIL import Image
-from autodistill.detection import CaptionOntology, DetectionBaseModel
-from transformers import OwlViTProcessor, OwlViTForObjectDetection
+from transformers import OwlViTForObjectDetection, OwlViTProcessor
 
 HOME = os.path.expanduser("~")
 DEVICE = torch.device("cuda" if torch.cuda.is_available() else "cpu")
 
-model = OwlViTForObjectDetection.from_pretrained("google/owlvit-base-patch32").to(DEVICE)
-processor = OwlViTProcessor.from_pretrained("google/owlvit-base-patch32")
+model = OwlViTForObjectDetection.from_pretrained("google/owlvit-large-patch14").to(
+    DEVICE
+)
+processor = OwlViTProcessor.from_pretrained("google/owlvit-large-patch14")
+
 
 @dataclass
 class OWLViT(DetectionBaseModel):
@@ -26,15 +29,28 @@ class OWLViT(DetectionBaseModel):
     def predict(self, input: str) -> sv.Detections:
         labels = self.ontology.prompts()
 
-        image = Image.open(input)
+        image = Image.open(input).convert("RGB")
 
         with torch.no_grad():
-            inputs = processor(text=labels, images=image, return_tensors="pt")
-            outputs = model(**inputs)
+            if isinstance(self.ontology, CaptionOntology):
+                inputs = processor(text=labels, images=image, return_tensors="pt").to(
+                    DEVICE
+                )
+                outputs = model(**inputs)
+            elif isinstance(self.ontology, DetectionOntology):
+                inputs = processor(
+                    query_images=labels, images=image, return_tensors="pt"
+                ).to(DEVICE)
+                outputs = model.image_guided_detection(**inputs)
+                outputs["pred_boxes"] = outputs["target_pred_boxes"]
 
-            target_sizes = torch.Tensor([image.size[::-1]])
+            target_sizes = torch.Tensor([image.size[::-1]]).to(DEVICE)
 
             results = processor.post_process(outputs=outputs, target_sizes=target_sizes)
+
+            results = [
+                {k: v.to(torch.device("cpu")) for k, v in t.items()} for t in results
+            ]
 
             i = 0
 


### PR DESCRIPTION
Hi, this PR adds in capability to use DetectionOntology with autodistill OWL-ViT. I also fixed what I think are errors in the device management, set the default model to OWL large because it's still a very manageable size and updated the readme with a detectionontology usage example. This repo is awesome!